### PR TITLE
Update expected Go version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,24 @@
 module github.com/chronosphereio/go-grpc-prometheus
 
-go 1.15
+go 1.20
+
+require (
+	github.com/golang/protobuf v1.3.2
+	github.com/m3db/prometheus_client_golang v0.8.1
+	github.com/m3db/prometheus_client_model v0.1.0
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
+	google.golang.org/grpc v1.18.0
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/protobuf v1.3.2
-	github.com/m3db/prometheus_client_golang v0.8.1
-	github.com/m3db/prometheus_client_model v0.1.0
 	github.com/m3db/prometheus_common v0.1.0 // indirect
 	github.com/m3db/prometheus_procfs v0.8.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/stretchr/testify v1.3.0
-	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
-	google.golang.org/grpc v1.18.0
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,14 +2,12 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
```console
$ make all
go vet github.com/chronosphereio/go-grpc-prometheus github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/client github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/protobuf github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/server github.com/chronosphereio/go-grpc-prometheus/examples/testproto
go fmt github.com/chronosphereio/go-grpc-prometheus github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/client github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/protobuf github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/server github.com/chronosphereio/go-grpc-prometheus/examples/testproto
./scripts/test_all.sh
TESTS FOR: for github.com/chronosphereio/go-grpc-prometheus
=== RUN   TestClientInterceptorSuite
=== RUN   TestClientInterceptorSuite/TestStartedStreamingIncrementsStarted
=== RUN   TestClientInterceptorSuite/TestStreamingIncrementsMetrics
=== RUN   TestClientInterceptorSuite/TestUnaryIncrementsMetrics
=== NAME  TestClientInterceptorSuite
    client_test.go:92: stopped grpc.Server at: 127.0.0.1:60233
--- PASS: TestClientInterceptorSuite (0.01s)
    --- PASS: TestClientInterceptorSuite/TestStartedStreamingIncrementsStarted (0.00s)
    --- PASS: TestClientInterceptorSuite/TestStreamingIncrementsMetrics (0.00s)
    --- PASS: TestClientInterceptorSuite/TestUnaryIncrementsMetrics (0.00s)
=== RUN   TestServerInterceptorSuite
=== RUN   TestServerInterceptorSuite/TestRegisterPresetsStuff
=== RUN   TestServerInterceptorSuite/TestStartedStreamingIncrementsStarted
=== RUN   TestServerInterceptorSuite/TestStreamingIncrementsMetrics
=== RUN   TestServerInterceptorSuite/TestUnaryIncrementsMetrics
=== NAME  TestServerInterceptorSuite
    server_test.go:104: stopped grpc.Server at: 127.0.0.1:60235
--- PASS: TestServerInterceptorSuite (0.37s)
    --- PASS: TestServerInterceptorSuite/TestRegisterPresetsStuff (0.06s)
    --- PASS: TestServerInterceptorSuite/TestStartedStreamingIncrementsStarted (0.20s)
    --- PASS: TestServerInterceptorSuite/TestStreamingIncrementsMetrics (0.11s)
    --- PASS: TestServerInterceptorSuite/TestUnaryIncrementsMetrics (0.00s)
PASS
        github.com/chronosphereio/go-grpc-prometheus    coverage: 65.9% of statements
ok      github.com/chronosphereio/go-grpc-prometheus    0.561s  coverage: 65.9% of statements

TESTS FOR: for github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/client
?       github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/client        [no test files]

TESTS FOR: for github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/protobuf
?       github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/protobuf      [no test files]

TESTS FOR: for github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/server
?       github.com/chronosphereio/go-grpc-prometheus/examples/grpc-server-with-prometheus/server        [no test files]

TESTS FOR: for github.com/chronosphereio/go-grpc-prometheus/examples/testproto
?       github.com/chronosphereio/go-grpc-prometheus/examples/testproto [no test files]
```